### PR TITLE
Add visual editor for card configuration

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,205 @@
+# Visual Editor for HNL Power Bars Card — Implementation Plan
+
+## Overview
+
+Home Assistant's Lovelace UI supports a **built-in visual editor system** for custom cards. When a card registers a config element via `static getConfigElement()`, HA renders that element inside its card-configuration dialog instead of showing raw YAML. This is the standard, well-supported approach used by all major custom cards.
+
+The editor is a separate LitElement web component (`hnl-power-bars-card-editor`) that:
+- Receives the current config and `hass` object
+- Renders form controls for every configuration option
+- Fires `config-changed` CustomEvents whenever the user modifies a value
+- HA handles the rest (saving, YAML sync, undo, etc.)
+
+---
+
+## Architecture
+
+```
+src/
+├── hnl-power-bars-card.js          ← existing card (add getConfigElement)
+├── editor/
+│   ├── hnl-power-bars-card-editor.js   ← main editor component
+│   ├── entity-list-editor.js           ← reusable entity list sub-editor
+│   └── remainder-editor.js             ← remainder config sub-editor
+├── const.js                         ← existing (no changes)
+└── utils.js                         ← existing (no changes)
+```
+
+**Why split into sub-components?**
+Production and consumption are both arrays of entity configs. A reusable `entity-list-editor` avoids duplicating the add/remove/reorder/edit logic. The remainder config is a distinct shape, so it gets its own small sub-editor.
+
+---
+
+## Step-by-Step Implementation
+
+### Step 1: Create the main editor component (`editor/hnl-power-bars-card-editor.js`)
+
+Register a new custom element `hnl-power-bars-card-editor` extending `LitElement`.
+
+**Properties:** `hass`, `_config` (internal copy of the card config).
+
+**`setConfig(config)`** — called by HA with the current card config. Store it internally.
+
+**`render()`** — return a Lit `html` template with these sections:
+
+#### Section A: Global Settings
+Using native HA form elements for best UX consistency:
+
+| Option | Control | HA Element |
+|---|---|---|
+| `unit_of_measurement` | Text input | `<ha-textfield>` |
+| `rounding` | Number input (0–6) | `<ha-textfield type="number">` |
+| `hide_zero_values` | Toggle | `<ha-switch>` |
+| `transparent` | Toggle | `<ha-switch>` |
+| `easing` | Toggle | `<ha-switch>` |
+
+#### Section B: Production Entities
+Render an `<entity-list-editor>` with:
+- `hass` pass-through
+- `entities` = current production array
+- `label` = "Production Sources"
+- `@entities-changed` event listener → update `_config.production`
+
+#### Section C: Consumption Entities
+Same as above but for consumption.
+
+#### Section D: Production Remainder (collapsible)
+Render a `<remainder-editor>` for `production_remainder`.
+
+#### Section E: Consumption Remainder (collapsible)
+Render a `<remainder-editor>` for `consumption_remainder`.
+
+**`_valueChanged()`** — on any input change, fire:
+```js
+this.dispatchEvent(new CustomEvent("config-changed", {
+  detail: { config: this._config },
+  bubbles: true, composed: true,
+}));
+```
+
+**Styling** — Use HA's design tokens (`--primary-text-color`, `--divider-color`, etc.) so the editor looks native. Use `ha-expansion-panel` for collapsible sections.
+
+---
+
+### Step 2: Create the entity list sub-editor (`editor/entity-list-editor.js`)
+
+A reusable component for editing an array of entity configs (used for both production and consumption).
+
+**UI per entity row:**
+| Field | Control |
+|---|---|
+| `entity` | `<ha-entity-picker>` — native HA entity picker with autocomplete |
+| `icon` | `<ha-icon-picker>` — native HA icon picker |
+| `color` | `<ha-textfield>` (CSS color string) |
+| `unit_of_measurement` | `<ha-textfield>` (optional override) |
+
+**Row actions:**
+- **Drag handle** — for reordering (use `<ha-sortable>` if available, or manual move-up/move-down buttons as fallback)
+- **Delete button** — remove entity from list
+- **Add button** — at the bottom, adds a new empty entity row
+
+Each row is rendered inside an `ha-expansion-panel` showing the entity's friendly name as the header, so users can collapse configured entities and focus on the one they're editing.
+
+**Events:** Fires `entities-changed` with the updated array whenever any field changes.
+
+---
+
+### Step 3: Create the remainder sub-editor (`editor/remainder-editor.js`)
+
+For editing `production_remainder` or `consumption_remainder`.
+
+**Fields:**
+| Field | Control |
+|---|---|
+| `name` | `<ha-textfield>` |
+| `icon` | `<ha-icon-picker>` |
+| `color` | `<ha-textfield>` |
+| `bg_opacity` | `<ha-textfield>` |
+| `text_color` | `<ha-textfield>` |
+| `unit_of_measurement` | `<ha-textfield>` |
+
+Wrapped in an `ha-expansion-panel` so it's collapsible by default (remainder config is optional/advanced).
+
+**Events:** Fires `remainder-changed` with the updated remainder object.
+
+---
+
+### Step 4: Register the editor in the main card
+
+In `hnl-power-bars-card.js`, add:
+
+```js
+static getConfigElement() {
+  return document.createElement("hnl-power-bars-card-editor");
+}
+```
+
+And import the editor module at the top of the file so the custom element is registered:
+
+```js
+import './editor/hnl-power-bars-card-editor.js';
+```
+
+---
+
+### Step 5: Update the Rollup build
+
+The editor files are new ES module imports from the main card file, so Rollup will automatically bundle them — **no rollup config changes needed**. The tree of imports starting from `hnl-power-bars-card.js` will pull in the editor and its sub-components.
+
+Verify the bundled output size stays reasonable (Lit is already included; the editor just adds more templates).
+
+---
+
+### Step 6: Testing & Validation
+
+1. **Manual testing in HA** — Add the card via the UI, confirm the visual editor appears instead of YAML.
+2. **Round-trip test** — Configure via editor → switch to YAML view → verify YAML is correct → switch back to editor → verify fields populated correctly.
+3. **Edge cases:**
+   - Empty config (only required fields)
+   - Many entities (5+ production, 5+ consumption)
+   - Entity with all optional fields filled
+   - Remainder with/without custom values
+   - Config created in YAML with shorthand strings (e.g., `production: ["sensor.solar"]`) — editor should handle normalized and raw formats
+4. **Styling** — Verify editor looks correct in both light and dark HA themes.
+
+---
+
+## HA Editor Elements Reference
+
+These are built-in HA elements available in the editor context (no imports needed):
+
+| Element | Purpose |
+|---|---|
+| `<ha-entity-picker>` | Entity selector with autocomplete, filtering by domain |
+| `<ha-icon-picker>` | MDI icon selector with search |
+| `<ha-textfield>` | Material text input |
+| `<ha-switch>` | Toggle switch |
+| `<ha-expansion-panel>` | Collapsible section |
+| `<ha-sortable>` | Drag-and-drop reordering container |
+| `<ha-button>` | Material button |
+| `<ha-icon-button>` | Icon-only button |
+| `<ha-alert>` | Info/warning banners |
+
+These elements automatically inherit HA theming and provide accessible, consistent UX.
+
+---
+
+## Estimated Scope
+
+| Component | Approximate Lines |
+|---|---|
+| `hnl-power-bars-card-editor.js` | ~200 |
+| `entity-list-editor.js` | ~180 |
+| `remainder-editor.js` | ~80 |
+| Changes to `hnl-power-bars-card.js` | ~3 |
+| **Total new code** | **~460** |
+
+---
+
+## Summary of Changes
+
+1. **New file:** `src/editor/hnl-power-bars-card-editor.js` — main editor orchestrator
+2. **New file:** `src/editor/entity-list-editor.js` — reusable entity list editor
+3. **New file:** `src/editor/remainder-editor.js` — remainder config editor
+4. **Modified:** `src/hnl-power-bars-card.js` — add import + `getConfigElement()` static method
+5. **No changes** to build config, dependencies, or existing card rendering logic

--- a/src/editor/entity-list-editor.js
+++ b/src/editor/entity-list-editor.js
@@ -1,0 +1,172 @@
+import { LitElement, html, css } from 'lit';
+
+class EntityListEditor extends LitElement {
+
+  static get properties() {
+    return {
+      hass: { type: Object },
+      entities: { type: Array },
+      label: { type: String },
+    };
+  }
+
+  constructor() {
+    super();
+    this.entities = [];
+  }
+
+  _fireChanged() {
+    this.dispatchEvent(new CustomEvent('entities-changed', {
+      detail: { entities: [...this.entities] },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  _addEntity() {
+    this.entities = [...this.entities, { entity: '' }];
+    this._fireChanged();
+  }
+
+  _removeEntity(index) {
+    this.entities = this.entities.filter((_, i) => i !== index);
+    this._fireChanged();
+  }
+
+  _moveEntity(index, direction) {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= this.entities.length) return;
+    const updated = [...this.entities];
+    const temp = updated[index];
+    updated[index] = updated[newIndex];
+    updated[newIndex] = temp;
+    this.entities = updated;
+    this._fireChanged();
+  }
+
+  _entityFieldChanged(index, field, value) {
+    const updated = [...this.entities];
+    updated[index] = { ...updated[index], [field]: value };
+    this.entities = updated;
+    this._fireChanged();
+  }
+
+  _getEntityName(entityConfig) {
+    const entityId = entityConfig.entity;
+    if (!entityId) return 'New entity';
+    const stateObj = this.hass?.states[entityId];
+    return stateObj?.attributes?.friendly_name || entityId;
+  }
+
+  _renderEntityRow(entity, index) {
+    const name = this._getEntityName(entity);
+
+    return html`
+      <ha-expansion-panel .header=${name} outlined>
+        <div slot="icons" class="row-actions">
+          <ha-icon-button
+            .label=${'Move up'}
+            @click=${(ev) => { ev.stopPropagation(); this._moveEntity(index, -1); }}
+            ?disabled=${index === 0}
+          >
+            <ha-icon icon="mdi:arrow-up"></ha-icon>
+          </ha-icon-button>
+          <ha-icon-button
+            .label=${'Move down'}
+            @click=${(ev) => { ev.stopPropagation(); this._moveEntity(index, 1); }}
+            ?disabled=${index === this.entities.length - 1}
+          >
+            <ha-icon icon="mdi:arrow-down"></ha-icon>
+          </ha-icon-button>
+          <ha-icon-button
+            .label=${'Remove'}
+            @click=${(ev) => { ev.stopPropagation(); this._removeEntity(index); }}
+          >
+            <ha-icon icon="mdi:delete"></ha-icon>
+          </ha-icon-button>
+        </div>
+
+        <div class="entity-fields">
+          <ha-entity-picker
+            .hass=${this.hass}
+            .value=${entity.entity || ''}
+            .label=${'Entity'}
+            allow-custom-entity
+            @value-changed=${(ev) =>
+              this._entityFieldChanged(index, 'entity', ev.detail.value)}
+          ></ha-entity-picker>
+
+          <ha-icon-picker
+            .hass=${this.hass}
+            .label=${'Icon (optional)'}
+            .value=${entity.icon || ''}
+            @value-changed=${(ev) =>
+              this._entityFieldChanged(index, 'icon', ev.detail.value)}
+          ></ha-icon-picker>
+
+          <ha-textfield
+            .label=${'Color (CSS, optional)'}
+            .value=${entity.color || ''}
+            @input=${(ev) =>
+              this._entityFieldChanged(index, 'color', ev.target.value)}
+          ></ha-textfield>
+
+          <ha-textfield
+            .label=${'Unit of measurement (optional)'}
+            .value=${entity.unit_of_measurement || ''}
+            @input=${(ev) =>
+              this._entityFieldChanged(index, 'unit_of_measurement', ev.target.value)}
+          ></ha-textfield>
+        </div>
+      </ha-expansion-panel>
+    `;
+  }
+
+  render() {
+    return html`
+      <div class="entity-list">
+        <h3>${this.label || 'Entities'}</h3>
+        ${this.entities.map((ent, i) => this._renderEntityRow(ent, i))}
+        <ha-button @click=${this._addEntity}>
+          <ha-icon icon="mdi:plus" slot="icon"></ha-icon>
+          Add entity
+        </ha-button>
+      </div>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      .entity-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      h3 {
+        margin: 16px 0 4px;
+        font-size: 1em;
+        font-weight: 500;
+        color: var(--primary-text-color);
+      }
+      .entity-fields {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 12px 0;
+      }
+      .row-actions {
+        display: flex;
+        align-items: center;
+      }
+      ha-textfield,
+      ha-entity-picker {
+        display: block;
+      }
+      ha-button {
+        align-self: flex-start;
+      }
+    `;
+  }
+}
+
+customElements.define('entity-list-editor', EntityListEditor);

--- a/src/editor/hnl-power-bars-card-editor.js
+++ b/src/editor/hnl-power-bars-card-editor.js
@@ -1,0 +1,223 @@
+import { LitElement, html, css } from 'lit';
+import './entity-list-editor.js';
+import './remainder-editor.js';
+
+class HnlPowerBarsCardEditor extends LitElement {
+
+  static get properties() {
+    return {
+      hass: { type: Object },
+      _config: { state: true },
+    };
+  }
+
+  setConfig(config) {
+    this._config = {
+      ...config,
+      production: this._normalizeEntities(config.production),
+      consumption: this._normalizeEntities(config.consumption),
+    };
+  }
+
+  _normalizeEntities(input) {
+    if (!input) return [];
+    const list = Array.isArray(input) ? input : [input];
+    return list.map((item) =>
+      typeof item === 'string' ? { entity: item } : { ...item }
+    );
+  }
+
+  _fireConfigChanged() {
+    const config = { ...this._config };
+
+    // Clean up empty optional fields to keep YAML tidy
+    if (!config.unit_of_measurement) delete config.unit_of_measurement;
+
+    // Clean entity arrays: remove entries with no entity selected
+    config.production = config.production.filter((e) => e.entity);
+    config.consumption = config.consumption.filter((e) => e.entity);
+
+    // Strip empty optional fields from entities
+    const cleanEntity = (ent) => {
+      const cleaned = { entity: ent.entity };
+      if (ent.icon) cleaned.icon = ent.icon;
+      if (ent.color) cleaned.color = ent.color;
+      if (ent.unit_of_measurement) cleaned.unit_of_measurement = ent.unit_of_measurement;
+      if (ent.bg_opacity) cleaned.bg_opacity = ent.bg_opacity;
+      if (ent.text_color) cleaned.text_color = ent.text_color;
+      return cleaned;
+    };
+    config.production = config.production.map(cleanEntity);
+    config.consumption = config.consumption.map(cleanEntity);
+
+    // Clean remainder objects: only include if user customized them
+    ['production_remainder', 'consumption_remainder'].forEach((key) => {
+      if (config[key]) {
+        const r = config[key];
+        const hasCustomValues = r.name || r.icon || r.color || r.bg_opacity || r.text_color || r.unit_of_measurement;
+        if (!hasCustomValues) {
+          delete config[key];
+        }
+      }
+    });
+
+    this.dispatchEvent(new CustomEvent('config-changed', {
+      detail: { config },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  _toggleChanged(field, ev) {
+    this._config = { ...this._config, [field]: ev.target.checked };
+    this._fireConfigChanged();
+  }
+
+  _textChanged(field, ev) {
+    this._config = { ...this._config, [field]: ev.target.value };
+    this._fireConfigChanged();
+  }
+
+  _numberChanged(field, ev) {
+    const val = parseInt(ev.target.value, 10);
+    this._config = { ...this._config, [field]: isNaN(val) ? 0 : val };
+    this._fireConfigChanged();
+  }
+
+  _productionChanged(ev) {
+    this._config = { ...this._config, production: ev.detail.entities };
+    this._fireConfigChanged();
+  }
+
+  _consumptionChanged(ev) {
+    this._config = { ...this._config, consumption: ev.detail.entities };
+    this._fireConfigChanged();
+  }
+
+  _productionRemainderChanged(ev) {
+    this._config = { ...this._config, production_remainder: ev.detail.remainder };
+    this._fireConfigChanged();
+  }
+
+  _consumptionRemainderChanged(ev) {
+    this._config = { ...this._config, consumption_remainder: ev.detail.remainder };
+    this._fireConfigChanged();
+  }
+
+  render() {
+    if (!this.hass || !this._config) return html``;
+
+    return html`
+      <div class="editor">
+
+        <div class="section">
+          <h3>General Settings</h3>
+
+          <ha-textfield
+            .label=${'Unit of measurement'}
+            .value=${this._config.unit_of_measurement || ''}
+            @input=${(ev) => this._textChanged('unit_of_measurement', ev)}
+          ></ha-textfield>
+
+          <ha-textfield
+            .label=${'Decimal places (rounding)'}
+            .value=${String(this._config.rounding ?? 0)}
+            type="number"
+            min="0"
+            max="6"
+            @input=${(ev) => this._numberChanged('rounding', ev)}
+          ></ha-textfield>
+
+          <div class="toggle-row">
+            <span>Hide zero values</span>
+            <ha-switch
+              .checked=${this._config.hide_zero_values ?? true}
+              @change=${(ev) => this._toggleChanged('hide_zero_values', ev)}
+            ></ha-switch>
+          </div>
+
+          <div class="toggle-row">
+            <span>Transparent background</span>
+            <ha-switch
+              .checked=${this._config.transparent ?? true}
+              @change=${(ev) => this._toggleChanged('transparent', ev)}
+            ></ha-switch>
+          </div>
+
+          <div class="toggle-row">
+            <span>Smooth transitions (easing)</span>
+            <ha-switch
+              .checked=${this._config.easing ?? false}
+              @change=${(ev) => this._toggleChanged('easing', ev)}
+            ></ha-switch>
+          </div>
+        </div>
+
+        <entity-list-editor
+          .hass=${this.hass}
+          .entities=${this._config.production || []}
+          .label=${'Production Sources'}
+          @entities-changed=${this._productionChanged}
+        ></entity-list-editor>
+
+        <entity-list-editor
+          .hass=${this.hass}
+          .entities=${this._config.consumption || []}
+          .label=${'Consumption Destinations'}
+          @entities-changed=${this._consumptionChanged}
+        ></entity-list-editor>
+
+        <remainder-editor
+          .hass=${this.hass}
+          .label=${'Production Remainder (Grid Import)'}
+          .remainder=${this._config.production_remainder || {}}
+          @remainder-changed=${this._productionRemainderChanged}
+        ></remainder-editor>
+
+        <remainder-editor
+          .hass=${this.hass}
+          .label=${'Consumption Remainder (Grid Export)'}
+          .remainder=${this._config.consumption_remainder || {}}
+          @remainder-changed=${this._consumptionRemainderChanged}
+        ></remainder-editor>
+
+      </div>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      .editor {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        padding: 16px 0;
+      }
+      .section {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      h3 {
+        margin: 0;
+        font-size: 1em;
+        font-weight: 500;
+        color: var(--primary-text-color);
+      }
+      .toggle-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 4px 0;
+      }
+      .toggle-row span {
+        color: var(--primary-text-color);
+      }
+      ha-textfield {
+        display: block;
+      }
+    `;
+  }
+}
+
+customElements.define('hnl-power-bars-card-editor', HnlPowerBarsCardEditor);

--- a/src/editor/remainder-editor.js
+++ b/src/editor/remainder-editor.js
@@ -1,0 +1,92 @@
+import { LitElement, html, css } from 'lit';
+
+class RemainderEditor extends LitElement {
+
+  static get properties() {
+    return {
+      hass: { type: Object },
+      label: { type: String },
+      remainder: { type: Object },
+    };
+  }
+
+  _fireChanged() {
+    this.dispatchEvent(new CustomEvent('remainder-changed', {
+      detail: { remainder: { ...this.remainder } },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  _valueChanged(field, ev) {
+    const value = ev.target.value;
+    this.remainder = { ...this.remainder, [field]: value };
+    this._fireChanged();
+  }
+
+  render() {
+    if (!this.remainder) return html``;
+
+    return html`
+      <ha-expansion-panel .header=${this.label || 'Remainder'} outlined>
+        <div class="remainder-fields">
+          <ha-textfield
+            .label=${'Name'}
+            .value=${this.remainder.name || ''}
+            @input=${(ev) => this._valueChanged('name', ev)}
+          ></ha-textfield>
+
+          <ha-icon-picker
+            .hass=${this.hass}
+            .label=${'Icon'}
+            .value=${this.remainder.icon || ''}
+            @value-changed=${(ev) => {
+              this.remainder = { ...this.remainder, icon: ev.detail.value };
+              this._fireChanged();
+            }}
+          ></ha-icon-picker>
+
+          <ha-textfield
+            .label=${'Color (CSS)'}
+            .value=${this.remainder.color || ''}
+            @input=${(ev) => this._valueChanged('color', ev)}
+          ></ha-textfield>
+
+          <ha-textfield
+            .label=${'Background opacity'}
+            .value=${this.remainder.bg_opacity || ''}
+            @input=${(ev) => this._valueChanged('bg_opacity', ev)}
+          ></ha-textfield>
+
+          <ha-textfield
+            .label=${'Text color (CSS)'}
+            .value=${this.remainder.text_color || ''}
+            @input=${(ev) => this._valueChanged('text_color', ev)}
+          ></ha-textfield>
+
+          <ha-textfield
+            .label=${'Unit of measurement'}
+            .value=${this.remainder.unit_of_measurement || ''}
+            @input=${(ev) => this._valueChanged('unit_of_measurement', ev)}
+          ></ha-textfield>
+        </div>
+      </ha-expansion-panel>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      .remainder-fields {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 12px 0;
+      }
+      ha-textfield {
+        display: block;
+      }
+    `;
+  }
+}
+
+customElements.define('remainder-editor', RemainderEditor);

--- a/src/hnl-power-bars-card.js
+++ b/src/hnl-power-bars-card.js
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { computeEntityIcon } from './utils.js';
 import { CARD_VERSION, CARD_NAME, CARD_DESCRIPTION } from './const.js';
+import './editor/hnl-power-bars-card-editor.js';
 
 console.info(
     `%c ${CARD_NAME.toUpperCase()} %c v${CARD_VERSION} `,
@@ -336,6 +337,11 @@ class HnlPowerBarsCard extends LitElement {
         };
     }
 
+
+    //part of HASS card API
+    static getConfigElement() {
+        return document.createElement("hnl-power-bars-card-editor");
+    }
 
     //part of HASS card API
     static getStubConfig() {


### PR DESCRIPTION
Implement a Lovelace visual editor so users can configure the card without writing YAML. The editor uses native HA form elements (ha-entity-picker, ha-icon-picker, ha-switch, ha-textfield) for a consistent experience.

New files:
- src/editor/hnl-power-bars-card-editor.js - main editor component
- src/editor/entity-list-editor.js - reusable entity list sub-editor
- src/editor/remainder-editor.js - remainder config sub-editor
- plan.md - implementation plan document

Changes:
- src/hnl-power-bars-card.js - add getConfigElement() and editor import

https://claude.ai/code/session_01L3ACNwZr1aH1UeoTpraNUC