### PR TITLE
Add energy_date_selection option to sync with HA Energy Dashboard

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,104 @@
+# Plan: Issue #11 — Sync with energy_date_selection component
+
+## Summary
+
+Add an `energy_date_selection` config option that, when enabled, subscribes to Home Assistant's Energy Dashboard date/period picker and displays aggregated statistics for the selected time range instead of current entity values.
+
+## Background
+
+Currently the card reads live entity states (e.g. `sensor.solar_power` = 1234 W). Issue #11 requests that when placed on HA's Energy Dashboard (or any view with a `type: energy-date-selection` card), the card should instead display **summed statistics** for the selected period (e.g. total kWh produced yesterday).
+
+The reference implementation (ha-sankey-chart) achieves this by:
+1. Polling `hass.connection._energy` to find the EnergyCollection object
+2. Subscribing to the collection's updates (which fire when the user changes the date range)
+3. Calling `recorder/statistics_during_period` WebSocket API to fetch statistics
+4. Replacing entity state values with the summed statistics for the period
+
+## Implementation Plan
+
+### Step 1: Add energy utility module (`src/energy.js`)
+
+Create a new module with:
+
+- **`getEnergyDataCollection(hass)`** — Access `hass.connection._energy` to retrieve HA's energy data collection (set up by the `energy-date-selection` card on the same view). Returns null if not available.
+
+- **`subscribeEnergyDateSelection(hass, callback)`** — Poll for the energy collection (100ms interval, 10s timeout). Once found, subscribe to updates. Each update provides `{ start, end }` dates. Returns an unsubscribe function.
+
+- **`fetchStatistics(hass, startTime, endTime, entityIds)`** — Call `recorder/statistics_during_period` WebSocket API. Determine period granularity from date range:
+  - >35 days → `"month"`
+  - >2 days → `"day"`
+  - ≤2 days → `"hour"`
+
+  Returns a `Record<entityId, number>` of summed values (using `sum` or `state` statistic type, computing the difference between last and first values for cumulative sensors).
+
+### Step 2: Update the main card (`src/hnl-flow-bars-card.js`)
+
+- **Add `energy_date_selection` to config handling** in `setConfig()` — store `this._rawConfig.energy_date_selection` (boolean, default `false`).
+
+- **Add reactive properties** — Add `_energyStats` (object) and `_energyError` (string) as tracked state.
+
+- **Lifecycle: `connectedCallback()` / `disconnectedCallback()`** — When `energy_date_selection` is true:
+  - In `connectedCallback`: call `subscribeEnergyDateSelection()`, store the unsubscribe function. On each update, call `fetchStatistics()` for all configured entity IDs, store results in `_energyStats`, trigger re-render.
+  - In `disconnectedCallback`: call the stored unsubscribe function.
+
+- **Modify `_hydrateParsedConfig()`** — When `energy_date_selection` is enabled and `_energyStats` is populated, use the statistic values from `_energyStats[entityId]` instead of `stateObj.state`. If a statistic is missing for an entity, fall back to 0 with a warning.
+
+- **Render error state** — If the energy collection isn't found within timeout, render an `<ha-alert>` explaining that a `type: energy-date-selection` card is required on the same view.
+
+### Step 3: Update the editor (`src/editor/hnl-flow-bars-card-editor.js`)
+
+- Add an `energy_date_selection` toggle (ha-formfield + ha-switch) in the General Settings section, with a description like "Sync with Energy Dashboard date picker".
+
+- Ensure the toggle value is read from and written to the config properly. Clean up the key when it's `false` (matching existing cleanup patterns).
+
+### Step 4: Update constants (`src/const.js`)
+
+- No changes needed unless we want to add a timeout constant (optional, can be inlined).
+
+### Step 5: Add tests (`test/energy.test.js`)
+
+- Test `fetchStatistics` period selection logic (month/day/hour based on date range)
+- Test statistic summing/differencing logic
+- Test that `_hydrateParsedConfig` uses energy stats when available
+
+### Step 6: Update existing tests
+
+- Ensure `card-logic.test.js` tests still pass (no breaking changes to existing functions since energy mode is opt-in)
+
+## Config Schema Change
+
+```yaml
+type: custom:hnl-flow-bars-card
+energy_date_selection: true    # NEW - opt-in
+production:
+  - entity: sensor.solar_energy_total
+consumption:
+  - entity: sensor.house_energy_total
+```
+
+## Key Design Decisions
+
+1. **Opt-in via boolean flag** — Matches the ha-sankey-chart approach. Default is `false` so existing users are unaffected.
+
+2. **Statistic type handling** — Energy sensors are typically cumulative (`state` type). We compute the net value as `last.state - first.state` for the period. For non-cumulative sensors that report `sum`, we use the `sum` field directly.
+
+3. **Polling for energy collection** — HA's energy collection is initialized asynchronously by the `energy-date-selection` card. We must poll `hass.connection._energy` until it appears (with timeout).
+
+4. **Period granularity** — Automatically selected based on date range width, matching HA's own energy dashboard behavior.
+
+5. **Graceful degradation** — If the energy collection isn't available (e.g., card not on energy dashboard), show a clear error message. If statistics are unavailable for a specific entity, show 0 with a warning.
+
+## Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `src/energy.js` | **Create** — Energy subscription and statistics fetching |
+| `src/hnl-flow-bars-card.js` | **Modify** — Add energy mode lifecycle, config, and data flow |
+| `src/editor/hnl-flow-bars-card-editor.js` | **Modify** — Add toggle in editor UI |
+| `test/energy.test.js` | **Create** — Tests for energy utilities |
+
+## Risks & Considerations
+
+- **HA internal API** — `hass.connection._energy` is an internal/undocumented API. It may change in future HA versions. However, this is the same approach used by ha-sankey-chart and other community cards, and HA's own energy dashboard cards use the same mechanism.
+- **Entity compatibility** — Not all entities have long-term statistics. The card should warn when statistics are unavailable for a configured entity.
+- **Performance** — Statistics fetches are async and may take time for large date ranges. Consider showing a loading indicator during fetch.

--- a/src/editor/hnl-flow-bars-card-editor.js
+++ b/src/editor/hnl-flow-bars-card-editor.js
@@ -43,6 +43,7 @@ class HnlFlowBarsCardEditor extends LitElement {
     const config = { ...this._config };
 
     if (!config.unit_of_measurement) delete config.unit_of_measurement;
+    if (!config.energy_date_selection) delete config.energy_date_selection;
     // Remove legacy key
     delete config.accolade_style;
     // Omit defaults to keep YAML clean
@@ -199,6 +200,17 @@ class HnlFlowBarsCardEditor extends LitElement {
             max="6"
             @input=${(ev) => this._numberChanged('rounding', ev)}
           ></ha-textfield>
+
+          <div class="toggle-row">
+            <div class="toggle-label">
+              <span>Energy date selection</span>
+              <span class="toggle-description">Sync with the Energy Dashboard date picker to show statistics for the selected period</span>
+            </div>
+            <ha-switch
+              .checked=${this._config.energy_date_selection ?? false}
+              @change=${(ev) => this._toggleChanged('energy_date_selection', ev)}
+            ></ha-switch>
+          </div>
 
           <div class="toggle-row">
             <div class="toggle-label">

--- a/src/energy.js
+++ b/src/energy.js
@@ -1,0 +1,164 @@
+/**
+ * Energy date selection subscription and statistics fetching.
+ *
+ * When the card is placed on a view that contains an `energy-date-selection`
+ * card, these utilities allow the card to subscribe to the selected date range
+ * and fetch aggregated statistics for that period instead of showing live
+ * entity states.
+ *
+ * Approach follows the same pattern used by ha-sankey-chart and other
+ * community cards that integrate with the HA Energy Dashboard.
+ */
+
+const ENERGY_DATA_TIMEOUT = 10_000; // ms to wait for energy collection
+const ENERGY_POLL_INTERVAL = 100;   // ms between polls
+
+/**
+ * Retrieve the energy data collection from the HA connection.
+ * Returns null if not (yet) available.
+ */
+export function getEnergyDataCollection(hass) {
+    return hass?.connection?.['_energy'] || null;
+}
+
+/**
+ * Subscribe to the energy date selection on the current view.
+ *
+ * Polls for the energy collection (initialised by an `energy-date-selection`
+ * card on the same view) and once found subscribes to its updates.
+ *
+ * @param {object}   hass     – Home Assistant connection object
+ * @param {function} callback – Called with `{ start: Date, end: Date }` on
+ *                              every date selection change and on initial load.
+ *                              Also receives the full energy `data` object as
+ *                              second argument.
+ * @returns {Promise<function>} Unsubscribe function
+ */
+export function subscribeEnergyDateSelection(hass, callback) {
+    let cancelled = false;
+    let collectionUnsub = null;
+
+    const promise = new Promise((resolve, reject) => {
+        const start = Date.now();
+
+        const poll = () => {
+            if (cancelled) {
+                resolve(() => {});
+                return;
+            }
+
+            const collection = getEnergyDataCollection(hass);
+            if (collection) {
+                // Subscribe to collection updates (fires on date change)
+                collectionUnsub = collection.subscribe((data) => {
+                    if (!cancelled) {
+                        callback(data);
+                    }
+                });
+
+                // Trigger an initial refresh so data is fetched immediately
+                if (typeof collection.refresh === 'function') {
+                    collection.refresh();
+                }
+
+                resolve(() => {
+                    cancelled = true;
+                    if (collectionUnsub) {
+                        collectionUnsub();
+                        collectionUnsub = null;
+                    }
+                });
+            } else if (Date.now() - start > ENERGY_DATA_TIMEOUT) {
+                reject(
+                    new Error(
+                        'No energy data received. Make sure to add a ' +
+                        '`type: energy-date-selection` card to this view.'
+                    )
+                );
+            } else {
+                setTimeout(poll, ENERGY_POLL_INTERVAL);
+            }
+        };
+
+        poll();
+    });
+
+    // Return the promise that resolves to the unsubscribe function
+    return promise;
+}
+
+/**
+ * Determine the statistics period granularity based on the date range.
+ *
+ * @param {Date} start
+ * @param {Date} end
+ * @returns {"month"|"day"|"hour"}
+ */
+export function selectPeriod(start, end) {
+    const msPerDay = 86_400_000;
+    const days = (end - start) / msPerDay;
+    if (days > 35) return 'month';
+    if (days > 2) return 'day';
+    return 'hour';
+}
+
+/**
+ * Fetch recorder statistics for the given entities over a date range.
+ *
+ * Uses the `recorder/statistics_during_period` WebSocket API to retrieve
+ * statistics, then sums them into a single value per entity.
+ *
+ * For cumulative sensors (energy meters) the net value is computed as the
+ * difference between the last and first `state` values. For non-cumulative
+ * sensors the `sum` field is used when available, otherwise `mean` is used.
+ *
+ * @param {object}   hass       – Home Assistant connection object
+ * @param {Date}     startTime  – Start of the period
+ * @param {Date}     endTime    – End of the period
+ * @param {string[]} entityIds  – Entity IDs to fetch statistics for
+ * @returns {Promise<Record<string, number>>} Map of entity_id → aggregated value
+ */
+export async function fetchStatistics(hass, startTime, endTime, entityIds) {
+    if (!entityIds.length) return {};
+
+    const period = selectPeriod(startTime, endTime);
+
+    const stats = await hass.callWS({
+        type: 'recorder/statistics_during_period',
+        start_time: startTime.toISOString(),
+        end_time: endTime.toISOString(),
+        statistic_ids: entityIds,
+        period,
+        types: ['state', 'sum', 'mean'],
+    });
+
+    const result = {};
+
+    for (const entityId of entityIds) {
+        const entries = stats[entityId];
+        if (!entries || entries.length === 0) {
+            result[entityId] = null;
+            continue;
+        }
+
+        // For cumulative sensors (e.g. energy), use the change in `state`
+        // between first and last entry if available.
+        const first = entries[0];
+        const last = entries[entries.length - 1];
+
+        if (first.state != null && last.state != null) {
+            result[entityId] = last.state - first.state;
+        } else if (last.sum != null && first.sum != null) {
+            // Use the change in `sum` over the period
+            result[entityId] = last.sum - first.sum;
+        } else {
+            // Fallback: average the mean values across all entries
+            const means = entries.filter(e => e.mean != null).map(e => e.mean);
+            result[entityId] = means.length
+                ? means.reduce((a, b) => a + b, 0) / means.length
+                : null;
+        }
+    }
+
+    return result;
+}

--- a/src/hnl-flow-bars-card.js
+++ b/src/hnl-flow-bars-card.js
@@ -3,6 +3,7 @@ import { computeEntityIcon, resolveLayoutAndTheme } from './utils.js';
 import {
     CARD_VERSION, CARD_NAME, CARD_DESCRIPTION,
 } from './const.js';
+import { subscribeEnergyDateSelection, fetchStatistics } from './energy.js';
 import './editor/hnl-flow-bars-card-editor.js';
 
 console.info(
@@ -23,12 +24,79 @@ window.customCards.push({
 class HnlFlowBarsCard extends LitElement {
 
     _updatedParsedConfig = null;
+    _energyStats = null;
+    _energyError = null;
+    _energyLoading = false;
+    _energyUnsub = null;
+
     //part of LitElement interface
     static get properties() {
         return {
             hass: {},
             layout: { type: String },
+            _energyStats: { state: true },
+            _energyError: { state: true },
+            _energyLoading: { state: true },
         };
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._subscribeEnergy();
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        this._unsubscribeEnergy();
+    }
+
+    _subscribeEnergy() {
+        if (!this._rawConfig?.energy_date_selection) return;
+
+        this._energyLoading = true;
+        this._energyError = null;
+
+        subscribeEnergyDateSelection(this.hass, async (data) => {
+            if (!this.hass) return;
+
+            const entityIds = [
+                ...this._rawConfig.production.map(p => p.entity),
+                ...this._rawConfig.consumption.map(c => c.entity),
+            ];
+
+            try {
+                const stats = await fetchStatistics(
+                    this.hass,
+                    data.start,
+                    data.end || new Date(),
+                    entityIds,
+                );
+                this._energyStats = stats;
+                this._energyLoading = false;
+                this._energyError = null;
+                // Invalidate parsed config so it re-renders with new stats
+                this._updatedParsedConfig = this._hydrateParsedConfig();
+                this.requestUpdate();
+            } catch (err) {
+                this._energyError = err.message || 'Failed to fetch statistics';
+                this._energyLoading = false;
+            }
+        }).then(unsub => {
+            this._energyUnsub = unsub;
+        }).catch(err => {
+            this._energyError = err.message;
+            this._energyLoading = false;
+        });
+    }
+
+    _unsubscribeEnergy() {
+        if (this._energyUnsub) {
+            this._energyUnsub();
+            this._energyUnsub = null;
+        }
+        this._energyStats = null;
+        this._energyError = null;
+        this._energyLoading = false;
     }
 
     _roundOff(x, digits = this._parsedConfig.rounding) {
@@ -92,14 +160,20 @@ class HnlFlowBarsCard extends LitElement {
               };
             }
 
-            const raw = stateObj.state;
+            // Use energy statistics when available, otherwise use live state
+            const useEnergy = this._rawConfig.energy_date_selection && this._energyStats;
+            const raw = useEnergy && this._energyStats[entityId] != null
+                ? String(this._energyStats[entityId])
+                : stateObj.state;
             const isUnavailable = raw === 'unavailable' || raw === 'unknown';
             const parsed = parseFloat(raw);
             const isNonNumeric = !isUnavailable && isNaN(parsed);
             let value = Math.max(0, parsed || 0);
             const displayName = item.name || stateObj.attributes.friendly_name || entityId;
             let warning = null;
-            if (isUnavailable) {
+            if (useEnergy && this._energyStats[entityId] == null) {
+              warning = `${displayName}: no statistics available for this period`;
+            } else if (isUnavailable) {
               warning = `${displayName}: ${raw}`;
             } else if (isNonNumeric) {
               warning = `${displayName}: non-numeric state "${raw}"`;
@@ -275,6 +349,26 @@ class HnlFlowBarsCard extends LitElement {
             return html``;
         }
 
+        if (this._rawConfig.energy_date_selection && this._energyError) {
+            return html`
+                <ha-card class="${this._parsedConfig.card_class}">
+                    <div class="card-content">
+                        <ha-alert alert-type="error">${this._energyError}</ha-alert>
+                    </div>
+                </ha-card>
+            `;
+        }
+
+        if (this._rawConfig.energy_date_selection && this._energyLoading && !this._energyStats) {
+            return html`
+                <ha-card class="${this._parsedConfig.card_class}">
+                    <div class="card-content">
+                        <ha-alert alert-type="info">Loading energy data…</ha-alert>
+                    </div>
+                </ha-card>
+            `;
+        }
+
         const productionTotal = this._parsedConfig.production.reduce((sum, ent) => sum + ent.value, 0);
         const consumptionTotal = this._parsedConfig.consumption.reduce((sum, ent) => sum + ent.value, 0);
 
@@ -408,8 +502,15 @@ class HnlFlowBarsCard extends LitElement {
             rounding: config.rounding ?? 0,
             transparent: config.transparent ?? true,
             unit_of_measurement: config.unit_of_measurement,
+            energy_date_selection: config.energy_date_selection ?? false,
             grid_options: config.grid_options || {},
         };
+
+        // Re-subscribe if energy mode changed while connected
+        if (this.isConnected) {
+            this._unsubscribeEnergy();
+            this._subscribeEnergy();
+        }
     }
 
 

--- a/test/energy.test.js
+++ b/test/energy.test.js
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest';
+import { selectPeriod, fetchStatistics, getEnergyDataCollection } from '../src/energy.js';
+
+describe('selectPeriod', () => {
+    it('returns "hour" for ranges of 2 days or less', () => {
+        const start = new Date('2025-01-01T00:00:00Z');
+        const end = new Date('2025-01-02T00:00:00Z');
+        expect(selectPeriod(start, end)).toBe('hour');
+    });
+
+    it('returns "hour" for ranges exactly 2 days', () => {
+        const start = new Date('2025-01-01T00:00:00Z');
+        const end = new Date('2025-01-03T00:00:00Z');
+        expect(selectPeriod(start, end)).toBe('hour');
+    });
+
+    it('returns "day" for ranges between 2 and 35 days', () => {
+        const start = new Date('2025-01-01T00:00:00Z');
+        const end = new Date('2025-01-10T00:00:00Z');
+        expect(selectPeriod(start, end)).toBe('day');
+    });
+
+    it('returns "day" for exactly 35 days', () => {
+        const start = new Date('2025-01-01T00:00:00Z');
+        const end = new Date('2025-02-05T00:00:00Z');
+        expect(selectPeriod(start, end)).toBe('day');
+    });
+
+    it('returns "month" for ranges over 35 days', () => {
+        const start = new Date('2025-01-01T00:00:00Z');
+        const end = new Date('2025-06-01T00:00:00Z');
+        expect(selectPeriod(start, end)).toBe('month');
+    });
+});
+
+describe('getEnergyDataCollection', () => {
+    it('returns null when hass is null', () => {
+        expect(getEnergyDataCollection(null)).toBeNull();
+    });
+
+    it('returns null when connection has no _energy', () => {
+        expect(getEnergyDataCollection({ connection: {} })).toBeNull();
+    });
+
+    it('returns the energy collection when available', () => {
+        const collection = { subscribe: () => {} };
+        const hass = { connection: { _energy: collection } };
+        expect(getEnergyDataCollection(hass)).toBe(collection);
+    });
+});
+
+describe('fetchStatistics', () => {
+    it('returns empty object for empty entity list', async () => {
+        const hass = { callWS: () => ({}) };
+        const result = await fetchStatistics(
+            hass,
+            new Date('2025-01-01'),
+            new Date('2025-01-02'),
+            [],
+        );
+        expect(result).toEqual({});
+    });
+
+    it('computes value from state difference for cumulative sensors', async () => {
+        const hass = {
+            callWS: async () => ({
+                'sensor.energy': [
+                    { state: 100, sum: null, mean: null },
+                    { state: 150, sum: null, mean: null },
+                    { state: 250, sum: null, mean: null },
+                ],
+            }),
+        };
+        const result = await fetchStatistics(
+            hass,
+            new Date('2025-01-01'),
+            new Date('2025-01-02'),
+            ['sensor.energy'],
+        );
+        expect(result['sensor.energy']).toBe(150); // 250 - 100
+    });
+
+    it('computes value from sum difference when state is not available', async () => {
+        const hass = {
+            callWS: async () => ({
+                'sensor.energy': [
+                    { state: null, sum: 10, mean: null },
+                    { state: null, sum: 30, mean: null },
+                    { state: null, sum: 50, mean: null },
+                ],
+            }),
+        };
+        const result = await fetchStatistics(
+            hass,
+            new Date('2025-01-01'),
+            new Date('2025-01-02'),
+            ['sensor.energy'],
+        );
+        expect(result['sensor.energy']).toBe(40); // 50 - 10
+    });
+
+    it('falls back to mean average when no state or sum', async () => {
+        const hass = {
+            callWS: async () => ({
+                'sensor.temp': [
+                    { state: null, sum: null, mean: 20 },
+                    { state: null, sum: null, mean: 22 },
+                    { state: null, sum: null, mean: 24 },
+                ],
+            }),
+        };
+        const result = await fetchStatistics(
+            hass,
+            new Date('2025-01-01'),
+            new Date('2025-01-02'),
+            ['sensor.temp'],
+        );
+        expect(result['sensor.temp']).toBe(22); // (20+22+24)/3
+    });
+
+    it('returns null for entities with no statistics', async () => {
+        const hass = {
+            callWS: async () => ({
+                'sensor.missing': [],
+            }),
+        };
+        const result = await fetchStatistics(
+            hass,
+            new Date('2025-01-01'),
+            new Date('2025-01-02'),
+            ['sensor.missing'],
+        );
+        expect(result['sensor.missing']).toBeNull();
+    });
+
+    it('returns null for entities not in response', async () => {
+        const hass = {
+            callWS: async () => ({}),
+        };
+        const result = await fetchStatistics(
+            hass,
+            new Date('2025-01-01'),
+            new Date('2025-01-02'),
+            ['sensor.unknown'],
+        );
+        expect(result['sensor.unknown']).toBeNull();
+    });
+
+    it('selects correct period based on date range', async () => {
+        let capturedMsg = null;
+        const hass = {
+            callWS: async (msg) => {
+                capturedMsg = msg;
+                return {};
+            },
+        };
+
+        // 60 day range → should use "month"
+        await fetchStatistics(
+            hass,
+            new Date('2025-01-01'),
+            new Date('2025-03-02'),
+            ['sensor.a'],
+        );
+        expect(capturedMsg.period).toBe('month');
+
+        // 7 day range → should use "day"
+        await fetchStatistics(
+            hass,
+            new Date('2025-01-01'),
+            new Date('2025-01-08'),
+            ['sensor.a'],
+        );
+        expect(capturedMsg.period).toBe('day');
+
+        // 1 day range → should use "hour"
+        await fetchStatistics(
+            hass,
+            new Date('2025-01-01'),
+            new Date('2025-01-02'),
+            ['sensor.a'],
+        );
+        expect(capturedMsg.period).toBe('hour');
+    });
+
+    it('handles multiple entities', async () => {
+        const hass = {
+            callWS: async () => ({
+                'sensor.solar': [
+                    { state: 0, sum: null, mean: null },
+                    { state: 500, sum: null, mean: null },
+                ],
+                'sensor.grid': [
+                    { state: 100, sum: null, mean: null },
+                    { state: 300, sum: null, mean: null },
+                ],
+            }),
+        };
+        const result = await fetchStatistics(
+            hass,
+            new Date('2025-01-01'),
+            new Date('2025-01-02'),
+            ['sensor.solar', 'sensor.grid'],
+        );
+        expect(result['sensor.solar']).toBe(500);
+        expect(result['sensor.grid']).toBe(200);
+    });
+});


### PR DESCRIPTION
When enabled, the card subscribes to the energy-date-selection component
on the same view and displays aggregated statistics for the selected
time period instead of live entity values. Uses the
recorder/statistics_during_period WebSocket API with automatic period
granularity selection (hour/day/month based on range).

Closes #11

https://claude.ai/code/session_01WwpmMzWVMkZ4nuvuKPYBs2