### PR TITLE
Added `transform` lambda support for sensor values

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The card is equipped with a visual editor, with which you can adjust all setting
 | `bg_opacity` | string | `inherit` | Background opacity (0–1) |
 | `text_color` | string | `inherit` | Text color override |
 | `unit_of_measurement` | string | from entity | Unit override |
+| `transform` | string | | Optional JS arrow expression to transform the entity value (e.g. `x => x / 1000`) |
 
 ### Remainder options
 
@@ -211,6 +212,7 @@ consumption:
   - entity: sensor.ev_charger_power
     icon: mdi:car-electric
     color: "#2196f3"
+    transform: "x => x < 25 ? 0 : x"
 production_remainder:
   name: Grid import
   icon: mdi:transmission-tower-import

--- a/src/editor/entity-list-editor.js
+++ b/src/editor/entity-list-editor.js
@@ -166,6 +166,16 @@ class EntityListEditor extends LitElement {
             @input=${(ev) =>
               this._entityFieldChanged(index, 'unit_of_measurement', ev.target.value)}
           ></ha-textfield>
+
+          <ha-input
+            .label=${'Transform lambda (optional)'}
+            .value=${entity.transform || ''}
+            .placeholder=${'x => x / 1000'}
+            .helper=${'Arrow function to transform value: x => x * 2, x => Math.abs(x), etc.'}
+            helperPersistent
+            @input=${(ev) =>
+              this._entityFieldChanged(index, 'transform', ev.target.value)}
+          ></ha-input>
         </div>
       </ha-expansion-panel>
     `;

--- a/src/editor/hnl-flow-bars-card-editor.js
+++ b/src/editor/hnl-flow-bars-card-editor.js
@@ -65,6 +65,7 @@ class HnlFlowBarsCardEditor extends LitElement {
       if (ent.unit_of_measurement) cleaned.unit_of_measurement = ent.unit_of_measurement;
       if (ent.bg_opacity) cleaned.bg_opacity = ent.bg_opacity;
       if (ent.text_color) cleaned.text_color = ent.text_color;
+      if (ent.transform) cleaned.transform = ent.transform;
       return cleaned;
     };
     config.production = config.production.map(cleanEntity);

--- a/src/hnl-flow-bars-card.js
+++ b/src/hnl-flow-bars-card.js
@@ -1,5 +1,8 @@
 import { LitElement, html, css } from 'lit';
-import { computeEntityIcon, resolveLayoutAndTheme } from './utils.js';
+import {
+    computeEntityIcon, resolveLayoutAndTheme,
+    applyTransform
+} from './utils.js';
 import {
     CARD_VERSION, CARD_NAME, CARD_DESCRIPTION,
 } from './const.js';
@@ -172,7 +175,13 @@ class HnlFlowBarsCard extends LitElement {
             const isUnavailable = raw === 'unavailable' || raw === 'unknown';
             const parsed = parseFloat(raw);
             const isNonNumeric = !isUnavailable && isNaN(parsed);
-            let value = Math.max(0, parsed || 0);
+            let value = parsed || 0;
+
+            if (!isUnavailable && !isNonNumeric) {
+                value = applyTransform(value, item.transform);
+            }
+            value = Math.max(0, value);
+
             const displayName = item.name || stateObj.attributes.friendly_name || entityId;
             let warning = null;
             if (useEnergy && this._energyStats[entityId] == null) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -172,3 +172,43 @@ export function computeEntityIcon(stateObj) {
             return 'mdi:bookmark-outline';
     }
 }
+
+/**
+ * Helps to apply transformations to sensor values based on user-provided JavaScript code snippets.
+ * The `transform` parameter is expected to be a string representing an arrow function, e.g. "x => x * 2".
+ * The `createTransformFunction` compiles this string into a callable function.
+ * The `applyTransform` function applies the transformation to a given value and attempts to parse it as a float.
+ * If any step fails (invalid code, runtime error, or non-numeric result), it gracefully returns the original value.
+ */
+
+export function createTransformFunction(transform) {
+    if (!transform || typeof transform !== 'string') {
+        return null;
+    }
+
+    try {
+        // Create a function from the arrow function string which should be like "x => x * 2"
+        return new Function('x', `"use strict"; return (${transform})(x)`);
+    } catch (err) {
+        return null;
+    }
+}
+
+export function applyTransform(value, transform) {
+    if (!transform) {
+        return value;
+    }
+
+    const transformFunction = createTransformFunction(transform);
+    if (!transformFunction) {
+        return value;
+    }
+
+    try {
+        const raw = transformFunction(value);
+        const parsed = parseFloat(raw);
+        return isNaN(parsed) ? value : parsed;
+    } catch (err) {
+        return value;
+    }
+}

--- a/test/card-logic.test.js
+++ b/test/card-logic.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { applyTransform } from '../src/utils.js';
 
 /**
  * Tests for the core calculation logic in HnlFlowBarsCard.
@@ -295,5 +296,37 @@ describe('normalizeEntityConfig', () => {
     it('throws on invalid input', () => {
         expect(() => normalizeEntityConfig(42)).toThrow('Invalid entity format');
         expect(() => normalizeEntityConfig({})).toThrow('Invalid entity format');
+    });
+});
+
+describe('Transform functions', () => {
+    it('applies simple multiplication transform', () => {
+        expect(applyTransform(100, 'x => x * 2')).toBe(200);
+        expect(applyTransform(50, 'x => x * 2')).toBe(100);
+    });
+
+    it('applies complex mathematical operations', () => {
+        expect(applyTransform(16, 'x => Math.sqrt(x)')).toBe(4);
+        expect(applyTransform(2, 'x => Math.pow(x, 3)')).toBe(8);
+    });
+
+    it('applies conditional transforms', () => {
+        expect(applyTransform(2000, 'x => x > 1000 ? x / 1000 : x')).toBe(2);
+        expect(applyTransform(500, 'x => x > 1000 ? x / 1000 : x')).toBe(500);
+    });
+
+    it('returns original value if transform is null', () => {
+        expect(applyTransform(100, null)).toBe(100);
+        expect(applyTransform(50, '')).toBe(50);
+    });
+
+    it('returns original value if transform has syntax error', () => {
+        expect(applyTransform(100, 'invalid syntax')).toBe(100);
+        expect(applyTransform(100, 'x =>')).toBe(100);
+    });
+
+    it('returns original value if transform returns non-numeric', () => {
+        expect(applyTransform(100, 'x => "string"')).toBe(100);
+        expect(applyTransform(100, 'x => null')).toBe(100);
     });
 });


### PR DESCRIPTION
This adds a `transform` configuration option for entities that can do a transformation on the sensor value. A few scenarios where this can help users:

* Clamp near-zero values to zero, allowing to hide them. An example might be an EVCS that consumes a few watts when it's not charging a car. 
  * `x => x < 25 ? 0 : x`
  * Fixes #18
* Allows to "invert" a sensor. This for example allows a single battery sensor to be added as production and consumption entity. The negative "battery discharging" value can be inverted to a positive number.
  * `x => -x`

A few screenshots showing the change in action:

<img width="1043" height="272" alt="screenshot" src="https://github.com/user-attachments/assets/6fd02a08-e80d-4001-9d8a-d7cf4f4d54e2" />

<img width="1046" height="311" alt="screenshot" src="https://github.com/user-attachments/assets/fb012d7d-d369-42ec-ac04-5a6f868f8690" />