### PR TITLE
Update `ha-textfield` to `ha-input`

### DIFF
--- a/src/editor/entity-list-editor.js
+++ b/src/editor/entity-list-editor.js
@@ -112,13 +112,13 @@ class EntityListEditor extends LitElement {
               this._entityFieldChanged(index, 'entity', ev.detail.value)}
           ></ha-entity-picker>
 
-          <ha-textfield
+          <ha-input
             .label=${'Name (optional)'}
             .value=${entity.name || ''}
             .placeholder=${this._getEntityName({ entity: entity.entity })}
             @input=${(ev) =>
               this._entityFieldChanged(index, 'name', ev.target.value)}
-          ></ha-textfield>
+          ></ha-input>
 
           <ha-icon-picker
             .hass=${this.hass}
@@ -128,21 +128,21 @@ class EntityListEditor extends LitElement {
               this._entityFieldChanged(index, 'icon', ev.detail.value)}
           ></ha-icon-picker>
 
-          <ha-textfield
+          <ha-input
             .label=${'Color (CSS, optional)'}
             .value=${entity.color || ''}
             .helper=${'Any CSS color: #hex, rgb(), var(--name)'}
             helperPersistent
             @input=${(ev) =>
               this._entityFieldChanged(index, 'color', ev.target.value)}
-          ></ha-textfield>
+          ></ha-input>
 
-          <ha-textfield
+          <ha-input
             .label=${'Text color (CSS, optional)'}
             .value=${entity.text_color || ''}
             @input=${(ev) =>
               this._entityFieldChanged(index, 'text_color', ev.target.value)}
-          ></ha-textfield>
+          ></ha-input>
 
           <div class="slider-row">
             <label>Background opacity</label>
@@ -160,12 +160,12 @@ class EntityListEditor extends LitElement {
             </div>
           </div>
 
-          <ha-textfield
+          <ha-input
             .label=${'Unit of measurement (optional)'}
             .value=${entity.unit_of_measurement || ''}
             @input=${(ev) =>
               this._entityFieldChanged(index, 'unit_of_measurement', ev.target.value)}
-          ></ha-textfield>
+          ></ha-input>
         </div>
       </ha-expansion-panel>
     `;
@@ -234,7 +234,7 @@ class EntityListEditor extends LitElement {
         align-items: center;
       }
 
-      ha-textfield,
+      ha-input,
       ha-entity-picker {
         display: block;
       }

--- a/src/editor/hnl-flow-bars-card-editor.js
+++ b/src/editor/hnl-flow-bars-card-editor.js
@@ -187,38 +187,38 @@ class HnlFlowBarsCardEditor extends LitElement {
             <h3>General</h3>
           </div>
 
-          <ha-textfield
+          <ha-input
             .label=${'Unit of measurement'}
             .value=${this._config.unit_of_measurement || ''}
             .helper=${'Override the unit for all entities (e.g. W, L/min, m\u00B3)'}
             helperPersistent
             @input=${(ev) => this._textChanged('unit_of_measurement', ev)}
-          ></ha-textfield>
+          ></ha-input>
 
-          <ha-textfield
+          <ha-input
             .label=${'Decimal places'}
             .value=${String(this._config.rounding ?? 0)}
             type="number"
             min="0"
             max="6"
             @input=${(ev) => this._numberChanged('rounding', ev)}
-          ></ha-textfield>
+          ></ha-input>
 
-          <ha-textfield
+          <ha-input
             .label=${'Default color (CSS, optional)'}
             .value=${this._config.global_color || ''}
             .helper=${'Fallback bar color when not set per entity'}
             helperPersistent
             @input=${(ev) => this._textChanged('global_color', ev)}
-          ></ha-textfield>
+          ></ha-input>
 
-          <ha-textfield
+          <ha-input
             .label=${'Default text color (CSS, optional)'}
             .value=${this._config.global_text_color || ''}
             .helper=${'Fallback text color when not set per entity'}
             helperPersistent
             @input=${(ev) => this._textChanged('global_text_color', ev)}
-          ></ha-textfield>
+          ></ha-input>
 
           <div class="slider-row">
             <label>Default background opacity</label>
@@ -538,7 +538,7 @@ class HnlFlowBarsCardEditor extends LitElement {
         border-bottom: 1px solid var(--divider-color, rgba(0, 0, 0, 0.12));
       }
 
-      ha-textfield {
+      ha-input {
         display: block;
       }
 

--- a/src/editor/remainder-editor.js
+++ b/src/editor/remainder-editor.js
@@ -38,13 +38,13 @@ class RemainderEditor extends LitElement {
         <div class="remainder-content">
           ${this.description ? html`<p class="remainder-description">${this.description}</p>` : ''}
           <div class="remainder-fields">
-            <ha-textfield
+            <ha-input
               .label=${'Display name'}
               .value=${this.remainder.name || ''}
               .helper=${'Label shown on the bar'}
               helperPersistent
               @input=${(ev) => this._valueChanged('name', ev)}
-            ></ha-textfield>
+            ></ha-input>
 
             <ha-icon-picker
               .hass=${this.hass}
@@ -56,13 +56,13 @@ class RemainderEditor extends LitElement {
               }}
             ></ha-icon-picker>
 
-            <ha-textfield
+            <ha-input
               .label=${'Color (CSS)'}
               .value=${this.remainder.color || ''}
               .helper=${'Any CSS color: #hex, rgb(), var(--name)'}
               helperPersistent
               @input=${(ev) => this._valueChanged('color', ev)}
-            ></ha-textfield>
+            ></ha-input>
 
             <div class="slider-row">
               <label>Background opacity</label>
@@ -79,17 +79,17 @@ class RemainderEditor extends LitElement {
               </div>
             </div>
 
-            <ha-textfield
+            <ha-input
               .label=${'Text color (CSS)'}
               .value=${this.remainder.text_color || ''}
               @input=${(ev) => this._valueChanged('text_color', ev)}
-            ></ha-textfield>
+            ></ha-input>
 
-            <ha-textfield
+            <ha-input
               .label=${'Unit of measurement'}
               .value=${this.remainder.unit_of_measurement || ''}
               @input=${(ev) => this._valueChanged('unit_of_measurement', ev)}
-            ></ha-textfield>
+            ></ha-input>
           </div>
         </div>
       </ha-expansion-panel>
@@ -130,7 +130,7 @@ class RemainderEditor extends LitElement {
         gap: 12px;
       }
 
-      ha-textfield {
+      ha-input {
         display: block;
       }
 


### PR DESCRIPTION
Seems the `ha-textfield` was deprecated and removed, see https://developers.home-assistant.io/blog/2026/03/25/frontend-component-updates-2026.4/

This PR updates those fields to the new `ha-input` fields.