### PR TITLE
Add support for font size overrides

### DIFF
--- a/src/editor/hnl-flow-bars-card-editor.js
+++ b/src/editor/hnl-flow-bars-card-editor.js
@@ -46,6 +46,7 @@ class HnlFlowBarsCardEditor extends LitElement {
     if (!config.global_color) delete config.global_color;
     if (!config.global_text_color) delete config.global_text_color;
     if (!config.global_bg_opacity) delete config.global_bg_opacity;
+    if (!config.font_size) delete config.font_size;
     if (!config.energy_date_selection) delete config.energy_date_selection;
     // Remove legacy key
     delete config.accolade_style;
@@ -237,6 +238,14 @@ class HnlFlowBarsCardEditor extends LitElement {
               <span class="slider-value">${this._config.global_bg_opacity || '1'}</span>
             </div>
           </div>
+
+          <ha-input
+            .label=${'Font size (CSS value, optional)'}
+            .value=${this._config.font_size || ''}
+            .helper=${'Scale factor (e.g. 1.2, 0.8) or absolute value (e.g. 16px, 1.2em)'}
+            helperPersistent
+            @input=${(ev) => this._textChanged('font_size', ev)}
+          ></ha-input>
 
           <h4 class="subsection-header">Behavior</h4>
 

--- a/src/hnl-flow-bars-card.js
+++ b/src/hnl-flow-bars-card.js
@@ -223,6 +223,7 @@ class HnlFlowBarsCard extends LitElement {
             rounding: this._rawConfig.rounding,
             hide_zero_values: this._rawConfig.hide_zero_values,
             unit_of_measurement: this._rawConfig.unit_of_measurement,
+            font_size: this._rawConfig.font_size,
             card_class: [
                 this._rawConfig.transparent ? 'transparent' : '',
                 this._rawConfig.theme === 'minimal' ? 'minimal' : '',
@@ -425,6 +426,12 @@ class HnlFlowBarsCard extends LitElement {
         const visibleProd = barData.production.filter((ent) => this._shouldShowBar(ent));
         const visibleCons = barData.consumption.filter((ent) => this._shouldShowBar(ent));
 
+        const fontSizeValue = this._parsedConfig.font_size?.trim();
+        const flowBarsStyle = !fontSizeValue ? '' :
+            /^\d+(\.\d+)?$/.test(fontSizeValue) // If it has no units, it's a scale value
+                ? `--user-font-size-scale: ${fontSizeValue};`
+                : `--user-font-size: ${fontSizeValue};`;
+
         return html`
             <ha-card class="${this._parsedConfig.card_class}">
                 ${this._parsedConfig.warnings.length ? html`
@@ -435,7 +442,7 @@ class HnlFlowBarsCard extends LitElement {
                     </div>
                 ` : null}
                 <div class="card-content">
-        <hnl-flow-bars class="${this._flowBarsClasses}">
+        <hnl-flow-bars class="${this._flowBarsClasses}" style="${flowBarsStyle}">
             <hnl-flow-bar-source-group>
                 <hnl-flow-bar-source-labels>
                     ${visibleProd.map((ent) => this._renderSourceLabel(ent))}
@@ -525,6 +532,7 @@ class HnlFlowBarsCard extends LitElement {
             global_color: config.global_color || null,
             global_text_color: config.global_text_color || null,
             global_bg_opacity: config.global_bg_opacity || null,
+            font_size: config.font_size || null,
             energy_date_selection: config.energy_date_selection ?? false,
             grid_options: config.grid_options || {},
         };
@@ -731,16 +739,16 @@ class HnlFlowBarsCard extends LitElement {
             }
 
             hnl-flow-bar-source-label,
-            hnl-flow-bar-source-accolade,
-            hnl-flow-bar-destination {
-                display: flex;
-                flex: var(--bar-grow, 0) 1 var(--bar-width, 0);
-                transition: flex-basis 0.3s ease;
-				font-size: clamp(var(--ha-font-size-xs, 9px), 22cqb, 14px);
-                --mdc-icon-size: min(1.25em, 1.2em);
-                --label-padding: 0.15em 0.5em;
-                --label-edge-padding: 0.7em;
-            }
+             hnl-flow-bar-source-accolade,
+             hnl-flow-bar-destination {
+                 display: flex;
+                 flex: var(--bar-grow, 0) 1 var(--bar-width, 0);
+                 transition: flex-basis 0.3s ease;
+ 				font-size: var(--user-font-size, calc(var(--user-font-size-scale, 1) * clamp(var(--ha-font-size-xs, 9px), 22cqb, 14px)));
+                 --mdc-icon-size: min(1.25em, 1.2em);
+                 --label-padding: 0.15em 0.5em;
+                 --label-edge-padding: 0.7em;
+             }
 			
 			hnl-flow-bar-source-group,
 			hnl-flow-bar-destination-group {

--- a/src/hnl-flow-bars-card.js
+++ b/src/hnl-flow-bars-card.js
@@ -739,16 +739,16 @@ class HnlFlowBarsCard extends LitElement {
             }
 
             hnl-flow-bar-source-label,
-             hnl-flow-bar-source-accolade,
-             hnl-flow-bar-destination {
-                 display: flex;
-                 flex: var(--bar-grow, 0) 1 var(--bar-width, 0);
-                 transition: flex-basis 0.3s ease;
+            hnl-flow-bar-source-accolade,
+            hnl-flow-bar-destination {
+                display: flex;
+                flex: var(--bar-grow, 0) 1 var(--bar-width, 0);
+                transition: flex-basis 0.3s ease;
  				font-size: var(--user-font-size, calc(var(--user-font-size-scale, 1) * clamp(var(--ha-font-size-xs, 9px), 22cqb, 14px)));
-                 --mdc-icon-size: min(1.25em, 1.2em);
-                 --label-padding: 0.15em 0.5em;
-                 --label-edge-padding: 0.7em;
-             }
+                --mdc-icon-size: min(1.25em, 1.2em);
+                --label-padding: 0.15em 0.5em;
+                --label-edge-padding: 0.7em;
+            }
 			
 			hnl-flow-bar-source-group,
 			hnl-flow-bar-destination-group {


### PR DESCRIPTION
I'm using the card on a display where it allows me to see what's going on. I increased the card's vertical size so it's easier to read, but the font was still rather small.

I've made a few changes where the user is allowed to change the font size to liking. Either by configuring a relative scale, or by using specific css units. What do you think about this idea?

